### PR TITLE
Add libreadline to the Dockerfile so that trepl can be built.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get install -y build-essential \
 	libfftw3-dev sox libsox-dev libsox-fmt-all \
 	libopenblas-dev
 
+# Install libreadline-dev so that trepl can be built.
+RUN apt-get install -y libreadline-dev
+
 RUN pip install "ipython[notebook]"
 
 RUN git clone https://github.com/torch/distro.git ~/torch --recursive


### PR DESCRIPTION
Without libreadline-dev, the trepl (th) does not build.